### PR TITLE
Fix inflight offline message ordering (#1356)

### DIFF
--- a/apps/vmq_server/test/vmq_test_utils.erl
+++ b/apps/vmq_server/test/vmq_test_utils.erl
@@ -72,8 +72,11 @@ disable_all_plugins() ->
                           ignore
                   end, Plugins),
     %% Disable Mod Plugins
-    _ = [vmq_plugin_mgr:disable_plugin(P) || P <- vmq_plugin:info(all)],
-    ok.
+    lists:foreach(fun ({_, vmq_lvldb_store, _, _}) ->
+                          ignore;
+                      (P) ->
+                          vmq_plugin_mgr:disable_plugin(P)
+                  end, vmq_plugin:info(all)).
 
 maybe_start_distribution(Name) ->
     case ets:info(sys_dist) of

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,12 @@
 - Fix typo in `vmq-admin listener start` command (#1348).
 - Optimize subscription performance when many retained messages are stored on
   the broker and the subscription contains wildcards.
+- Fix bug where MQTT 5 publish expiry interval was lost when writing the message
+  to the message store.
+- Fix bug where a retried MQTT publish after resuming an offline session used
+  the wrong message id.
+- Fix MQTT 5 shared subscription bug where writing the message to the message
+  store resulted in a corrupt message record once a offline session was resumed.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
* Don't disable the message store plugin during tests

* Ensure DUP message aren't compressed

* Ensure Expiry message aren't compressed

* Fix shared subscription bug that use the MQTTv5 Subscription Identifier property

The bug was triggered if a QoS > 0 message gets routed to a shared
subscription which uses the MQTTv5 Subscription Identifier propery. In
such a case the QoS wasn't correctly set for the message, resulting in a
corrupt message on disk. However one only experiences the issue if such
a 'corrupt' message was read from the message store as part of the
decompress step (maybe_deref/2).