### PR TITLE
Remove debug statement (#1868)

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_mongo.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mongo.erl
@@ -41,7 +41,6 @@ find(PoolName, Collection, Selector, Args) ->
                                   end).
 
 find_one(PoolName, Collection, Selector, Args) ->
-    lager:error("PoolName, Collection, Selector, Args ~p", [[PoolName, Collection, Selector, Args]]),
     poolboy:transaction(PoolName, fun(Worker) ->
                                           vmq_diversity_worker_wrapper:apply(Worker, mc_worker_api, find_one, [Collection, Selector, Args])
                                   end).

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Fix Retain Server cache race condition for messages originating from local node.
+- Remove debug logging statement for MongoDB in vmq_diversity
 
 ## VerneMQ 1.12.1
 


### PR DESCRIPTION
Remove leftover debug statement from MongoDB in vmq_diversity

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
